### PR TITLE
Fix entity references after default content import

### DIFF
--- a/localgov_demo.module
+++ b/localgov_demo.module
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * LocalGovDrupal demo module file.
+ */
+
+use \Drupal\node\Entity\Node;
+
+/**
+ * Implements hook_modules_installed().
+ */
+function localgov_demo_modules_installed($modules, $is_syncing) {
+
+  // Fix broken entity references.
+  if (!$is_syncing and in_array('localgov_demo', $modules)) {
+    $serializer = \Drupal::service('serializer');
+    $entity_repo = \Drupal::service('entity.repository');
+
+    // Entity reference fields to fix.
+    $fix_fields = [
+      'localgov_services_parent',
+      'localgov_guides_parent',
+      'localgov_step_parent',
+    ];
+
+    $dir = drupal_get_path('module', 'localgov_demo') . "/content/node";
+    foreach (glob($dir . "/*.json") as $filename) {
+      $contents = file_get_contents($filename);
+      $decoded = $serializer->decode($contents, 'hal_json');
+      foreach ($decoded['_embedded'] as $key => $embedded) {
+        $parts = explode('/', $key);
+        $field_name = end($parts);
+        if (in_array($field_name, $fix_fields)) {
+          $uuid = $embedded[0]['uuid'][0]['value'];
+          $parent = $entity_repo->loadEntityByUuid('node', $uuid);
+          $nid = $decoded['nid'][0]['value'];
+          $node = Node::load($nid);
+          $node->set($field_name, ['target_id' => $parent->id()]);
+          $node->save();
+        }
+      }
+    }
+  }
+}

--- a/localgov_demo.module
+++ b/localgov_demo.module
@@ -5,17 +5,20 @@
  * LocalGovDrupal demo module file.
  */
 
-use \Drupal\node\Entity\Node;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_modules_installed().
+ *
+ * Fix entity reference fields in default content.
+ *
+ * @see https://github.com/localgovdrupal/localgov_demo/issues/2
  */
 function localgov_demo_modules_installed($modules, $is_syncing) {
-
-  // Fix broken entity references.
-  if (!$is_syncing and in_array('localgov_demo', $modules)) {
-    $serializer = \Drupal::service('serializer');
-    $entity_repo = \Drupal::service('entity.repository');
+  if (!$is_syncing &&
+    in_array('default_content', $modules) &&
+    in_array('localgov_demo', $modules)
+  ) {
 
     // Entity reference fields to fix.
     $fix_fields = [
@@ -23,21 +26,32 @@ function localgov_demo_modules_installed($modules, $is_syncing) {
       'localgov_guides_parent',
       'localgov_step_parent',
     ];
+    $serializer = \Drupal::service('serializer');
+    $entity_repo = \Drupal::service('entity.repository');
 
+    // Iterate over all default node content.
     $dir = drupal_get_path('module', 'localgov_demo') . "/content/node";
     foreach (glob($dir . "/*.json") as $filename) {
+
+      // Load serialized content.
       $contents = file_get_contents($filename);
       $decoded = $serializer->decode($contents, 'hal_json');
+
+      // Iterate over all entity references.
       foreach ($decoded['_embedded'] as $key => $embedded) {
         $parts = explode('/', $key);
         $field_name = end($parts);
+
+        // Update entity reference.
         if (in_array($field_name, $fix_fields)) {
           $uuid = $embedded[0]['uuid'][0]['value'];
-          $parent = $entity_repo->loadEntityByUuid('node', $uuid);
-          $nid = $decoded['nid'][0]['value'];
-          $node = Node::load($nid);
-          $node->set($field_name, ['target_id' => $parent->id()]);
-          $node->save();
+          if ($parent = $entity_repo->loadEntityByUuid('node', $uuid)) {
+            $nid = $decoded['nid'][0]['value'];
+            if ($node = Node::load($nid)) {
+              $node->set($field_name, ['target_id' => $parent->id()]);
+              $node->save();
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Added `hook_modules_installed` to update reference from default content for the `localgov_services_parent`, `localgov_guides_parent` and `localgov_step_parent` fields. Fixes #5 

A description of the underlying issue can be found on #2 