### PR TITLE
Set homepage to published

### DIFF
--- a/content/node/9ded2023-2f32-4e5e-ac5c-c5d8503bbd1f.yml
+++ b/content/node/9ded2023-2f32-4e5e-ac5c-c5d8503bbd1f.yml
@@ -47,7 +47,10 @@ default:
       value: false
   revision_translation_affected:
     -
-      value: true
+      value: true    
+  moderation_state:
+    -
+      value: published
   path:
     -
       alias: /localgov-drupal-demo


### PR DESCRIPTION
When setting up the LocalGov demo site, I noticed that the homepage can't be viewed when you're not logged in, as it's not published.

I'm not sure if there's a good reason for this, but it seems to me that it would make sense for the home page to be published by default, so that people can see it if installing the demon content?

I've not tested this, just added in what looks right - might be good for someone to have a look over it, if you think it's a good idea!