### PR TITLE
[3.x] Clear the cache after setting the default front page

### DIFF
--- a/localgov_demo.install
+++ b/localgov_demo.install
@@ -21,6 +21,7 @@ function localgov_demo_install() {
   $system_site = \Drupal::configFactory()->getEditable('system.site');
   $system_site->set('page.front', '/localgov-drupal-demo');
   $system_site->save();
+  drupal_flush_all_caches();
 
   // Disable unwanted blocks from localgov_base and localgov_scarfolk.
   $blocks_to_disable = [


### PR DESCRIPTION
Fix #114

This is because if an install profile has set a front page, that will be
carried over until the cache is cleared.
See: https://github.com/localgovdrupal/localgov/pull/612
