### PR TITLE
fix: update class namespace

### DIFF
--- a/localgov_demo.module
+++ b/localgov_demo.module
@@ -5,7 +5,7 @@
  * LocalGovDrupal demo module file.
  */
 
-use Drupal\Core\Serialization\Yaml;
+use Drupal\Component\Serialization\Yaml;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
 


### PR DESCRIPTION
Fixes this PHPStan error

```sh
 ------ --------------------------------------------------------------------- 
  Line   modules/contrib/localgov_demo/localgov_demo.module                   
 ------ --------------------------------------------------------------------- 
  51     Call to static method decode() on an unknown class                   
         Drupal\Core\Serialization\Yaml.                                      
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols  
 ------ --------------------------------------------------------------------- 
```