### PR TITLE
fixes links to docs site

### DIFF
--- a/content/node/9ded2023-2f32-4e5e-ac5c-c5d8503bbd1f.yml
+++ b/content/node/9ded2023-2f32-4e5e-ac5c-c5d8503bbd1f.yml
@@ -199,7 +199,7 @@ default:
                   parent_delta: 0
           localgov_link:
             -
-              uri: 'https://localgovdrupal.org/'
+              uri: 'https://docs.localgovdrupal.org/'
               title: 'Read the docs'
               options: {  }
           localgov_opens_in_a_new_window:
@@ -1060,7 +1060,7 @@ default:
               format: wysiwyg
           localgov_button:
             -
-              uri: 'https://localgovdrupal.org/'
+              uri: 'https://docs.localgovdrupal.org/'
               title: 'Go to the documentation (opens new tab)'
               options: {  }
           localgov_colour_theme:


### PR DESCRIPTION
Closes #132 

## What does this change?
Fixes links to docs site.

## How to test

Go to homepage of site after installing demo module, click on
- Read the docs
- Go to the documentation

Both should now link to the docs site instead of our marketing site.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.