### PR TITLE
Remove reorder alert banner blocks

### DIFF
--- a/localgov_demo.install
+++ b/localgov_demo.install
@@ -37,11 +37,6 @@ function localgov_demo_install() {
     $services_home_block->save();
   }
 
-  // Set weight of localgov_alert_banner block to float up above the banner.
-  $alert_banner_block = \Drupal::configFactory()->getEditable('block.block.localgov_alert_banner');
-  $alert_banner_block->set('weight', '-10');
-  $alert_banner_block->save();
-
   // Create a link to Docs.
   $news_menu_item = MenuLinkContent::create([
     'title' => 'Docs',


### PR DESCRIPTION
Fix #134

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This doesn't actually do anything, but it is leaving a rouge block.block.localgov_alert_banner.yml that only contains a weight key during a config export if localgov_demo is left enabled.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->
Install localgov drupal, enable localgov demo, do config export.
You should no longer see the config export file block.block.localgov_alert_banner.yml that only contains a weight key.

## How can we measure success?

Demo content can still install and it looks the same, alert banners et all.
<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Block weights don't actually update?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->
