### PR TITLE
Mark support for Drupal 11 and drop Drupal 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "localgovdrupal/localgov_publications": "^1.0",
         "localgovdrupal/localgov_search": "^1.2",
         "localgovdrupal/localgov_services": "^2.1",
-        "localgovdrupal/localgov_step_by_step": "dev-feature/2.x/drupal-11-support as 2.1.8",
+        "localgovdrupal/localgov_step_by_step": "^2.1",
         "localgovdrupal/localgov_subsites": "^2.3",
         "localgovdrupal/localgov_workflows": "^1.2"
    }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_directories": "dev-feature/3.x/394-drupal-11-support as 3.2.2",
         "localgovdrupal/localgov_events": "dev-feature/drupal-11-support as 3.0.3",
-        "localgovdrupal/localgov_guides": "dev-feature/2.x/drupal-11-support as 2.1.13",
+        "localgovdrupal/localgov_guides": "^2.1",
         "localgovdrupal/localgov_news": "^2.3",
         "localgovdrupal/localgov_publications": "^1.0",
         "localgovdrupal/localgov_search": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "localgovdrupal/localgov_news": "^2.3",
         "localgovdrupal/localgov_publications": "^1.0",
         "localgovdrupal/localgov_search": "^1.2",
-        "localgovdrupal/localgov_services": "dev-feature/2.x/drupal-11-support as 2.1.15",
+        "localgovdrupal/localgov_services": "^2.1",
         "localgovdrupal/localgov_step_by_step": "dev-feature/2.x/drupal-11-support as 2.1.8",
         "localgovdrupal/localgov_subsites": "^2.3",
         "localgovdrupal/localgov_workflows": "^1.2"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/default_content": "^2.0@alpha",
         "localgovdrupal/localgov_alert_banner": "^1.2",
         "localgovdrupal/localgov_core": "^2.12",
-        "localgovdrupal/localgov_directories": "dev-feature/3.x/394-drupal-11-support as 3.2.2",
+        "localgovdrupal/localgov_directories": "^3.0",
         "localgovdrupal/localgov_events": "dev-feature/drupal-11-support as 3.0.3",
         "localgovdrupal/localgov_guides": "^2.1",
         "localgovdrupal/localgov_news": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "localgovdrupal/localgov_alert_banner": "^1.2",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_directories": "^3.0",
-        "localgovdrupal/localgov_events": "dev-feature/drupal-11-support as 3.0.3",
+        "localgovdrupal/localgov_events": "^3.0",
         "localgovdrupal/localgov_guides": "^2.1",
         "localgovdrupal/localgov_news": "^2.3",
         "localgovdrupal/localgov_publications": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
         "drupal/default_content": "^2.0@alpha",
         "localgovdrupal/localgov_alert_banner": "^1.2",
         "localgovdrupal/localgov_core": "^2.12",
-        "localgovdrupal/localgov_directories": "^3.0@alpha",
-        "localgovdrupal/localgov_events": "^3.0@alpha",
-        "localgovdrupal/localgov_guides": "^2.1",
-        "localgovdrupal/localgov_news": "^2.3",
+        "localgovdrupal/localgov_directories": "dev-feature/3.x/394-drupal-11-support as 3.2.2",
+        "localgovdrupal/localgov_events": "dev-feature/drupal-11-support as 3.0.3",
+        "localgovdrupal/localgov_guides": "dev-feature/2.x/drupal-11-support as 2.1.13",
+        "localgovdrupal/localgov_news": "dev-feature/drupal-11-support as 2.3.10",
         "localgovdrupal/localgov_publications": "^1.0",
         "localgovdrupal/localgov_search": "^1.2",
-        "localgovdrupal/localgov_services": "^2.1",
-        "localgovdrupal/localgov_step_by_step": "^2.1",
+        "localgovdrupal/localgov_services": "dev-feature/2.x/drupal-11-support as 2.1.15",
+        "localgovdrupal/localgov_step_by_step": "dev-feature/2.x/drupal-11-support as 2.1.8",
         "localgovdrupal/localgov_subsites": "^2.3",
-        "localgovdrupal/localgov_workflows": "^1.2"
+        "localgovdrupal/localgov_workflows": "dev-feature/1.x/drupal-11-support as 1.3.8",
    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         "localgovdrupal/localgov_directories": "dev-feature/3.x/394-drupal-11-support as 3.2.2",
         "localgovdrupal/localgov_events": "dev-feature/drupal-11-support as 3.0.3",
         "localgovdrupal/localgov_guides": "dev-feature/2.x/drupal-11-support as 2.1.13",
-        "localgovdrupal/localgov_news": "dev-feature/drupal-11-support as 2.3.10",
+        "localgovdrupal/localgov_news": "^2.3",
         "localgovdrupal/localgov_publications": "^1.0",
         "localgovdrupal/localgov_search": "^1.2",
         "localgovdrupal/localgov_services": "dev-feature/2.x/drupal-11-support as 2.1.15",
         "localgovdrupal/localgov_step_by_step": "dev-feature/2.x/drupal-11-support as 2.1.8",
         "localgovdrupal/localgov_subsites": "^2.3",
-        "localgovdrupal/localgov_workflows": "dev-feature/1.x/drupal-11-support as 1.3.8"
+        "localgovdrupal/localgov_workflows": "^1.2"
    }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
         "localgovdrupal/localgov_services": "dev-feature/2.x/drupal-11-support as 2.1.15",
         "localgovdrupal/localgov_step_by_step": "dev-feature/2.x/drupal-11-support as 2.1.8",
         "localgovdrupal/localgov_subsites": "^2.3",
-        "localgovdrupal/localgov_workflows": "dev-feature/1.x/drupal-11-support as 1.3.8",
+        "localgovdrupal/localgov_workflows": "dev-feature/1.x/drupal-11-support as 1.3.8"
    }
 }

--- a/localgov_demo.info.yml
+++ b/localgov_demo.info.yml
@@ -1,6 +1,6 @@
 name: LocalGov Demo Content
 description: Example content for demonstrating the LocalGov Drupal distribution and to help with development.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 


### PR DESCRIPTION
Running upgrade status highlighted that this module was not compatible with Drupal 11. This pr adds in Drupal 11 support and drops Drupal 9.