### PR TITLE
Enable Workflow Notifications, ensuring notifications are turned off

### DIFF
--- a/localgov_demo.info.yml
+++ b/localgov_demo.info.yml
@@ -26,8 +26,9 @@ dependencies:
   - localgov_services:localgov_services_sublanding
   - localgov_step_by_step:localgov_step_by_step
   - localgov_subsites:localgov_subsites
-  - localgov_workflows:localgov_workflows
   - localgov_workflows:localgov_review_date
+  - localgov_workflows:localgov_workflows
+  - localgov_workflows:localgov_workflows_notifications
 
 default_content:
   localgov_alert_banner:

--- a/localgov_demo.module
+++ b/localgov_demo.module
@@ -196,4 +196,11 @@ function localgov_demo_modules_installed($modules, $is_syncing) {
       \Drupal::service('pathauto.generator')->updateEntityAlias($node, 'update');
     }
   }
+
+  if (!$is_syncing && in_array('localgov_workflows_notifications', $modules, TRUE)) {
+    // Disable LocalGov workflow notifications emails.
+    $config = \Drupal::configFactory()->getEditable('localgov_workflows_notifications.settings');
+    $config->set('email_enabled', FALSE);
+    $config->save();
+  }
 }


### PR DESCRIPTION
Fixes #141

## What does this change?

Enabled the LocalGov Workflow Notifications module so service contacts are installed, but turns of notifications.

## How to test

It's possible to create service contacts and associate them with content after enabling the LocalGov Demo.
