### PR TITLE
set homepage via node id

### DIFF
--- a/localgov_demo.install
+++ b/localgov_demo.install
@@ -18,12 +18,6 @@ function localgov_demo_install($is_syncing) {
     $localgov_directories_venue_config->set('settings.handler_settings.target_bundles.area', 'area');
     $localgov_directories_venue_config->save();
 
-    // Set demo front page.
-    $system_site = \Drupal::configFactory()->getEditable('system.site');
-    $system_site->set('page.front', '/node/97');
-    $system_site->save();
-    drupal_flush_all_caches();
-
     // Disable unwanted blocks from localgov_base and localgov_scarfolk.
     $blocks_to_disable = [
       'block.block.views_block__services_block_service_list_base',

--- a/localgov_demo.install
+++ b/localgov_demo.install
@@ -20,7 +20,7 @@ function localgov_demo_install($is_syncing) {
 
     // Set demo front page.
     $system_site = \Drupal::configFactory()->getEditable('system.site');
-    $system_site->set('page.front', '/localgov-drupal-demo');
+    $system_site->set('page.front', '/node/97');
     $system_site->save();
     drupal_flush_all_caches();
 

--- a/localgov_demo.module
+++ b/localgov_demo.module
@@ -196,7 +196,6 @@ function localgov_demo_modules_installed($modules, $is_syncing) {
       \Drupal::service('pathauto.generator')->updateEntityAlias($node, 'update');
     }
 
-
     // Set demo front page - runs after default content import.
     $system_site = \Drupal::configFactory()->getEditable('system.site');
     $home = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['title' => 'Localgov Drupal Demo']);

--- a/localgov_demo.module
+++ b/localgov_demo.module
@@ -195,6 +195,16 @@ function localgov_demo_modules_installed($modules, $is_syncing) {
     foreach ($nodes as $node) {
       \Drupal::service('pathauto.generator')->updateEntityAlias($node, 'update');
     }
+
+
+    // Set demo front page - runs after default content import.
+    $system_site = \Drupal::configFactory()->getEditable('system.site');
+    $home = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['title' => 'Localgov Drupal Demo']);
+    if ($home) {
+      $home = reset($home);
+      $system_site->set('page.front', '/node/' . $home->id());
+      $system_site->save();
+    }
   }
 
   if (!$is_syncing && in_array('localgov_workflows_notifications', $modules, TRUE)) {


### PR DESCRIPTION
Closes #148 

## What does this change?

Sets homepage via node id, so it doesn't redirect back to the alias.

## How to test

Install LGD with this module, check when you go to homepage you see `localgov.ddev.site/` instead of `localgov.ddev.site/localgov-drupal-demo`

## How can we measure success?

No more redirects from homepage to node alias.

## Have we considered potential risks?

This presumes that the demo content module is being installed on a fresh site with no other content. If there is another node created `/node/97` will not be the correct node id.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.