### PR TITLE
Update localgov_demo reference to localgov_services_menu

### DIFF
--- a/localgov_demo.module
+++ b/localgov_demo.module
@@ -147,7 +147,7 @@ function localgov_demo_modules_installed($modules, $is_syncing) {
       $menu_item = MenuLinkContent::create([
         'title' => $services_link['title'],
         'link' => ['uri' => 'internal:/node/' . $target_node->id()],
-        'menu_name' => 'localgov_services_menu',
+        'menu_name' => 'localgov-services-menu',
         'expanded' => FALSE,
       ]);
       $menu_item->save();


### PR DESCRIPTION
Fix #155
Use hypens for the menu name:
  `localgov-services-menu`

This is the counterpart to https://github.com/localgovdrupal/localgov_services/pull/340

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Changes the reference to the menu `localgov_services_menu` to use the hyphen version.
This is to match with a PR on localgov_services that will also make that change.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Install this branch and the corresponding localgov_services branch.
Running `drush si localgov -y; drush en localgov_demo` should install without issue.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Menu name replaced and menu links remain added.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

We might have to make this version of localgov_demo depend on the corresponding version of localgov_services as a minimum version.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

<img width="1233" height="272" alt="Screenshot 2025-11-24 at 3 26 41 pm" src="https://github.com/user-attachments/assets/cc3525d3-04a8-4905-8b3c-e7285415aab6" />

## Accessibility

n/a

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->